### PR TITLE
WIP: Addon preferences

### DIFF
--- a/barnold for blender 2.79b/barnold/__init__.py
+++ b/barnold for blender 2.79b/barnold/__init__.py
@@ -14,7 +14,8 @@ bl_info = {
 }
 
 import bpy
-
+import sys
+import os
 
 class ArnoldRenderEngine(bpy.types.RenderEngine):
     bl_idname = "ARNOLD_RENDER"
@@ -133,18 +134,29 @@ class ArnoldRenderEngine(bpy.types.RenderEngine):
         engine.free(self)
 
 
-from . import engine
-from . import props
-from . import nodes
-from . import ops
-from . import ui
-
-
 def register():
+    from . import addon_preferences
+    addon_preferences.register()
+
+    from . import props
+    from . import nodes
+    from . import ops
+    from . import ui
+    from . import engine
+    from . import addon_preferences
+
     bpy.utils.register_class(ArnoldRenderEngine)
     nodes.register()
 
 
 def unregister():
+    from . import addon_preferences
+    from . import props
+    from . import nodes
+    from . import ops
+    from . import ui
+    from . import engine
+    from . import addon_preferences
+    addon_preferences.unregister()
     bpy.utils.unregister_class(ArnoldRenderEngine)
     nodes.unregister()

--- a/barnold for blender 2.79b/barnold/addon_preferences.py
+++ b/barnold for blender 2.79b/barnold/addon_preferences.py
@@ -1,0 +1,51 @@
+import bpy
+from bpy.types import Operator, AddonPreferences
+from bpy.props import StringProperty, IntProperty, BoolProperty
+import os
+import sys
+
+
+class ArnoldAddonPreferences(AddonPreferences):
+    bl_idname = __package__
+
+    arnold_path = StringProperty(
+        name="Arnold Path",
+        subtype="DIR_PATH")
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="IMPORTANT NOTICE:")
+        layout.label(text="if you have an ARNOLD_HOME environment set,it will \
+        override whatever setting you input here.")
+        layout.prop(self, "arnold_path")
+
+# Registration
+
+
+def register():
+    bpy.utils.register_class(ArnoldAddonPreferences)
+    try:
+        pth = os.environ["ARNOLD_HOME"]
+        print("ARNOLD_HOME env found")
+
+    except:
+        print("ARNOLD_HOME env not found, using the preferences.")
+        prefs = bpy.context.user_preferences.addons[__package__].preferences
+        pth = prefs.arnold_path
+
+    print("Setting Arnold path to: {}".format(pth))
+
+    pth = os.path.join(pth, "python")
+
+    if pth not in sys.path:
+        sys.path.append(pth)
+
+
+
+def unregister():
+    bpy.utils.unregister_class(ArnoldAddonPreferences)
+
+
+
+if __name__ == "__main__":
+    register()

--- a/barnold for blender 2.79b/barnold/engine/__init__.py
+++ b/barnold for blender 2.79b/barnold/engine/__init__.py
@@ -20,7 +20,7 @@ import bgl
 from mathutils import Matrix, Vector, geometry
 
 #sys.path.append(os.path.join(os.environ["ARNOLD_HOME"],"python"))
-sys.path.append(r"C:\Program Files\Blender Foundation\Blender\2.79\scripts\modules\Arnold-5.2.0.0-windows\python")
+#sys.path.append(r"C:\Program Files\Blender Foundation\Blender\2.79\scripts\modules\Arnold-5.2.0.0-windows\python")
 import arnold
 
 from ..nodes import (


### PR DESCRIPTION
Just made an initial version of what we've discussed in #6 , I will continue to work on it here so no need to push it to master for now.

It checks for an `ARNOLD_HOME` env. If it exist it adds `ARNOLD_HOME/python` to `sys.path` aka `PYTHONPATH`.
If it can't find the env it will look for the preferences. For now it requires you to:

- Set the path in Barnold preferences
- Save settings.
- Restart blender 🤦‍♂️ 

and then it will pickup.
